### PR TITLE
fix: resolve 4.x validation/CI failures

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -32,7 +32,9 @@ data "azurerm_storage_account" "storeacc" {
 }
 
 resource "random_password" "passwd" {
-  count       = (var.custom_boot_image.os_type == "linux" && var.disable_password_authentication == false && var.admin_password == null ? 1 : (var.custom_boot_image.os_type == "windows" && var.admin_password == null ? 1 : 0))
+  # `var.custom_boot_image` defaults to null, so guard the attribute access
+  # with `try()` to keep `tflint` happy during static analysis.
+  count       = (try(var.custom_boot_image.os_type, null) == "linux" && var.disable_password_authentication == false && var.admin_password == null ? 1 : (try(var.custom_boot_image.os_type, null) == "windows" && var.admin_password == null ? 1 : 0))
   length      = var.random_password_length
   min_upper   = 4
   min_lower   = 2
@@ -40,6 +42,6 @@ resource "random_password" "passwd" {
   special     = false
 
   keepers = {
-    admin_password = (var.custom_boot_image.os_type == "linux" ? local.linux_vm_name : (var.custom_boot_image.os_type == "windows" ? local.windows_vm_name : null))
+    admin_password = (try(var.custom_boot_image.os_type, null) == "linux" ? local.linux_vm_name : (try(var.custom_boot_image.os_type, null) == "windows" ? local.windows_vm_name : null))
   }
 }

--- a/resources.virtual.machine.custom.image.vhd.tf
+++ b/resources.virtual.machine.custom.image.vhd.tf
@@ -4,13 +4,13 @@ resource "azurerm_managed_disk" "custom_boot_image" {
   name                 = local.vm_os_disk_name
   location             = local.location
   resource_group_name  = local.resource_group_name
-  storage_account_type = var.custom_boot_image.storage_acct_type
+  storage_account_type = try(var.custom_boot_image.storage_acct_type, null)
   create_option        = "Import"
-  source_uri           = var.custom_boot_image.storage_uri
-  storage_account_id   = var.custom_boot_image.storage_acct_id
-  os_type              = var.custom_boot_image.os_type
-  disk_size_gb         = var.custom_boot_image.disk_size_gb
-  zone                 = var.custom_boot_image.availability_zone
+  source_uri           = try(var.custom_boot_image.storage_uri, null)
+  storage_account_id   = try(var.custom_boot_image.storage_acct_id, null)
+  os_type              = try(var.custom_boot_image.os_type, null)
+  disk_size_gb         = try(var.custom_boot_image.disk_size_gb, null)
+  zone                 = try(var.custom_boot_image.availability_zone, null)
   tags                 = merge({ "ResourceName" = local.vm_os_disk_name }, var.add_tags, var.os_disk_add_tags, )
 
   lifecycle {


### PR DESCRIPTION
Post-merge fix for CI failures introduced by Phase 1 4.x migration.

**Failing job:** TFLint
**Root cause:** tflint's static analysis tries to evaluate `var.custom_boot_image.os_type` (and other attributes) but the variable's default is `null`, which trips the new `azurerm_virtual_machine_invalid_vm_size` / `azurerm_managed_disk_invalid_os_type` rules with "Attempt to get attribute from null value".
**Fix:** Guard the attribute accesses with `try()`. Runtime semantics are unchanged — the resources are still gated by `count`/`instances_count` and the consuming code already tolerates null.

Validated locally:
- `terraform fmt -recursive -check` ✅
- `terraform init -backend=false -upgrade` ✅
- `terraform validate` ✅ Success
- `tflint --recursive --format compact --minimum-failure-severity=error` ✅ exit 0